### PR TITLE
Add support for positional args i.e. after --

### DIFF
--- a/cmd/eiam/gcloud.go
+++ b/cmd/eiam/gcloud.go
@@ -62,6 +62,8 @@ func newCmdGcloud() *cobra.Command {
 				return err
 			}
 
+
+
 			if !options.YesOption {
 				util.Confirm(map[string]string{
 					"Project":         gcloudCmdConfig.Project,
@@ -98,11 +100,21 @@ func runGcloudCommand() error {
 
 	// There has to be a better way to do this...
 	util.Logger.Infof("Running: [gcloud %s]\n\n", strings.Join(gcloudCmdArgs, " "))
-	cmdArgs := append(
-		gcloudCmdArgs,
-		"--impersonate-service-account", gcloudCmdConfig.ServiceAccountEmail,
-		"--verbosity=error",
-	)
+
+    gcloudOpts := gcloudCmdArgs
+    positionalArgs := []string{}
+    for i, v := range gcloudCmdArgs {
+        if v == "--" {
+            gcloudOpts = gcloudCmdArgs[:i]
+            positionalArgs = gcloudCmdArgs[i:]
+            break
+        }
+    }
+
+	cmdArgs := append([]string(nil), gcloudOpts...)
+	cmdArgs = append(cmdArgs, "--impersonate-service-account", gcloudCmdConfig.ServiceAccountEmail, "--verbosity=error")
+	cmdArgs = append(cmdArgs, positionalArgs...)
+
 	gcloud := viper.GetString("binarypaths.gcloud")
 	c := exec.Command(gcloud, cmdArgs...)
 	c.Stdout = os.Stdout


### PR DESCRIPTION
Extend support for commands like ssh which use positional arguments i.e. 
`eiam gcloud compute ssh <tunnel_host> -s <service_account> -R "<reason>" -- -L <localPort>:<targetHost>:<targetPort>`