### PR TITLE
fix: prepend kubectl token arg so that kubectl exec commands succeed

### DIFF
--- a/cmd/eiam/kubectl.go
+++ b/cmd/eiam/kubectl.go
@@ -102,7 +102,7 @@ func runKubectlCommand() error {
 	}
 
 	util.Logger.Infof("Running: [kubectl %s]\n\n", strings.Join(kubectlCmdArgs, " "))
-	kubectlAuth := append(kubectlCmdArgs, "--token", accessToken.GetAccessToken())
+	kubectlAuth := append([]string{"--token", accessToken.GetAccessToken()}, kubectlCmdArgs...)
 	kubectl := viper.GetString("binarypaths.kubectl")
 	c := exec.Command(kubectl, kubectlAuth...)
 	c.Stdout = os.Stdout


### PR DESCRIPTION
This addresses issue #82 by prepending the kubectl `--token` argument.